### PR TITLE
fix: keep yaml key with quotes not split by dot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
+.latest_commit_hash.txt
 src/github.com/wimspaargaren/yolov3/data/


### PR DESCRIPTION
This pull request introduces changes to the `src/gopkg.in/yaml.v2/decode.go` file to capture and utilize the original value of YAML nodes. The most important changes include adding a new field to the `node` struct, implementing a function to capture the original value, and modifying the `mapping` function to use this original value.

Enhancements to node structure and value handling:

* [`src/gopkg.in/yaml.v2/decode.go`](diffhunk://#diff-41aa3b1438a776ff4cef5f20126a0c3948c89a5768370906e6739f31ffb3b5f0R26): Added a new field `originalValue` to the `node` struct to store the original value of the YAML node.
* [`src/gopkg.in/yaml.v2/decode.go`](diffhunk://#diff-41aa3b1438a776ff4cef5f20126a0c3948c89a5768370906e6739f31ffb3b5f0R158-R177): Implemented the `captureOriginalValue` function to capture the original value from the YAML event. This function handles different scalar styles (double-quoted, single-quoted, and plain).

Modifications to decoder functions:

* [`src/gopkg.in/yaml.v2/decode.go`](diffhunk://#diff-41aa3b1438a776ff4cef5f20126a0c3948c89a5768370906e6739f31ffb3b5f0R158-R177): Updated the `scalar` method to use the `captureOriginalValue` function and set the `originalValue` field of the node.
* [`src/gopkg.in/yaml.v2/decode.go`](diffhunk://#diff-41aa3b1438a776ff4cef5f20126a0c3948c89a5768370906e6739f31ffb3b5f0R568): Modified the `mapping` function to retrieve and use the `originalValue` for map keys. This ensures that the original representation of the key is preserved. [[1]](diffhunk://#diff-41aa3b1438a776ff4cef5f20126a0c3948c89a5768370906e6739f31ffb3b5f0R568) [[2]](diffhunk://#diff-41aa3b1438a776ff4cef5f20126a0c3948c89a5768370906e6739f31ffb3b5f0R579)